### PR TITLE
Eliminate extra blank lines when changing directories

### DIFF
--- a/zsh-tab-colors.plugin.zsh
+++ b/zsh-tab-colors.plugin.zsh
@@ -1,8 +1,9 @@
 function automatic_iterm_tab_color_cwd () {
   python -c "import random; import os; \
-             random.seed('red'   + os.getcwd()); print((\"\\033]6;1;bg;red;brightness;\"   + str((random.randint(0,255)+255)/2)) + \"\\a\"); \
-             random.seed('green' + os.getcwd()); print((\"\\033]6;1;bg;green;brightness;\" + str((random.randint(0,255)+255)/2)) + \"\\a\"); \
-             random.seed('blue'  + os.getcwd()); print((\"\\033]6;1;bg;blue;brightness;\"  + str((random.randint(0,255)+255)/2)) + \"\\a\");"
+             random.seed('red'   + os.getcwd()); print((\"\\033]6;1;bg;red;brightness;\"   + str((random.randint(0,255)+255)/2)) + \"\\a\"),; \
+             random.seed('green' + os.getcwd()); print((\"\\033]6;1;bg;green;brightness;\" + str((random.randint(0,255)+255)/2)) + \"\\a\"),; \
+             random.seed('blue'  + os.getcwd()); print((\"\\033]6;1;bg;blue;brightness;\"  + str((random.randint(0,255)+255)/2)) + \"\\a\"),; \
+             print(\"\\r\"),"
 }
 
 automatic_iterm_tab_color_cwd 


### PR DESCRIPTION
@tysonwolker thanks for merging my last PR!

I've been very happy with those changes for several days now. However, I have noticed that is adding extra blank lines in between commands.

Every time I change directories, there are extra blank lines printed, followed by my prompt.

The changes in this PR fix that!

**Before:**

<img width="593" alt="before" src="https://user-images.githubusercontent.com/669/87361116-226f2480-c531-11ea-98e8-3c34d711e0d1.png">

**After:**

<img width="595" alt="after" src="https://user-images.githubusercontent.com/669/87361122-256a1500-c531-11ea-9cb0-c9d4cddd4fde.png">
