### PR TITLE
Avoid printing 3 empty lines on every dirchange

### DIFF
--- a/zsh-tab-colors.plugin.zsh
+++ b/zsh-tab-colors.plugin.zsh
@@ -1,8 +1,9 @@
 function automatic_iterm_tab_color_cwd () {
-  python -c "import random; import os; \
-             random.seed('red'   + os.getcwd()); print((\"\\033]6;1;bg;red;brightness;\"   + str((random.randint(0,255)+255)/2)) + \"\\a\"); \
-             random.seed('green' + os.getcwd()); print((\"\\033]6;1;bg;green;brightness;\" + str((random.randint(0,255)+255)/2)) + \"\\a\"); \
-             random.seed('blue'  + os.getcwd()); print((\"\\033]6;1;bg;blue;brightness;\"  + str((random.randint(0,255)+255)/2)) + \"\\a\");"
+  python -c "import random; import os; import sys; \
+             random.seed('red'   + os.getcwd()); sys.stdout.write((\"\\033]6;1;bg;red;brightness;\"   + str((random.randint(0,255)+255)/2)) + \"\\a\"); \
+             random.seed('green' + os.getcwd()); sys.stdout.write((\"\\033]6;1;bg;green;brightness;\" + str((random.randint(0,255)+255)/2)) + \"\\a\"); \
+             random.seed('blue'  + os.getcwd()); sys.stdout.write((\"\\033]6;1;bg;blue;brightness;\"  + str((random.randint(0,255)+255)/2)) + \"\\a\"); \
+             sys.stdout.flush();"
 }
 
 automatic_iterm_tab_color_cwd 


### PR DESCRIPTION
The solution using pythons native `print` statement adds a new emptyline after every time it's called. By writing to stdout directly, we can avoid the extra newlines. This will still work as expected, but no empty lines are printed on directory change.